### PR TITLE
Added osx targets to the project.

### DIFF
--- a/NetworkSession.xcodeproj/project.pbxproj
+++ b/NetworkSession.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.collectiveidea.NetworkSession;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -401,6 +402,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.collectiveidea.NetworkSession;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos macosx";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/NetworkSession/NetworkSession.h
+++ b/NetworkSession/NetworkSession.h
@@ -6,7 +6,7 @@
 //  Copyright © 2019 CollectiveIdea. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
 
 //! Project version number for NetworkSession.
 FOUNDATION_EXPORT double NetworkSessionVersionNumber;

--- a/NetworkSession/NetworkSession.swift
+++ b/NetworkSession/NetworkSession.swift
@@ -1,6 +1,5 @@
 
 import Foundation
-import MobileCoreServices
 
 public protocol NetworkSession {
     func post(to path: String, headers: [String: String]?, data: Data?, completion: @escaping (Result<Data, Error>) -> Void)


### PR DESCRIPTION
Removed MobileCoreServices import which is not needed.
Changed the header import to Foundation instead of UIKit since UIKit is not being used and breaks on OSX.